### PR TITLE
script for running both server and client code w/ ez terminate

### DIFF
--- a/scrape/start.sh
+++ b/scrape/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+pids=( )
+
+trap terminate SIGINT
+terminate() {
+  (( ${#pids[@]} )) && kill "${pids[@]}"
+}
+
+#the rest of your code goes here
+commands=(
+	"python server/server.py"
+	"npm start --prefix client/"
+)
+
+for  i in ${!commands[@]}; do
+  ${commands[$i]} & pids+=( "$!" )
+done
+
+for pid in "${pids[@]}"; do
+  wait "$pid" || (( retval |= $? ))
+done
+exit "$retval"


### PR DESCRIPTION
Run script in `scrape` folder using `./start.sh` and both client+server code will be ran. If you press `CTRL+C`, both client and server code will be terminated so we don't have to worry about running and re-running. In the future, we will have to run a lot of commands so we can add them into this bash script to simplify the process of running many commands but only have to press 1 button to run and terminate.