### PR TITLE
Use Docker Postgres URI As Default Connection String

### DIFF
--- a/scrape/server/flask_app/configuration/configuration.py
+++ b/scrape/server/flask_app/configuration/configuration.py
@@ -3,7 +3,7 @@ import os
 
 class Config:
     # declare environment variables here w/ their default values
-    POSTGRES_URL = ""
+    POSTGRES_URL = "postgres://postgres:password@localhost:5432/scrape?sslmode=disable"
     REDIS_URL = ""
 
     def __init__(self):

--- a/scrape/server/flask_app/models/postgres.py
+++ b/scrape/server/flask_app/models/postgres.py
@@ -12,6 +12,9 @@ class Postgres:
     conn = None
 
     def __init__(self, uri: str = "postgres://postgres:password@localhost:5432/scrape?sslmode=disable"):
+        # set default postgres uri to one that hits docker postgres
+        if uri == "": uri = "postgres://postgres:password@localhost:5432/scrape?sslmode=disable"
+        
         self.user, self.password, self.database, self.host, self.port = parse_uri(uri)
 
         try:


### PR DESCRIPTION
# Pull Request Review

| Status  | Type  |
| :---: | :---: |
| Ready | Feature |

## Description

Set default `POSTGRES_URL` to `postgres://postgres:password@localhost:5432/scrape?sslmode=disable`, which is the docker Postgres URI, so that we can test locally with minimal effort needed